### PR TITLE
Add `--ignore-empty-lines` option

### DIFF
--- a/doc/gmi2html.scdoc
+++ b/doc/gmi2html.scdoc
@@ -15,6 +15,9 @@ stdout.
 
 # OPTIONS
 
+*--ignore-empty-lines*
+    Do not convert empty lines into <p><br/></p> elements
+
 *--inline-images*
 	Translate links to images on the web (png,git,jpg,jpeg,webp) to <img> elements
 

--- a/tests/ignore_empty_lines_target.html
+++ b/tests/ignore_empty_lines_target.html
@@ -1,0 +1,43 @@
+<p>Hello world</p>
+<p>My name is charlie</p>
+<p>I write things here</p>
+<p>=&gt gemini://example.org/</p>
+<p>=&gt gemini://example.org/    	</p>
+<p>=&gt gemini://example.org/ An example link</p>
+<p>=&gt gemini://example.org/foo Another example link at the same host</p>
+<p>=&gtgemini://example.org/bar Yet another example link at the same host</p>
+<a style="display: block;" href="foo/bar/baz.txt">A relative link</a>
+<p>=&gt  gopher://example.org:70/1 A gopher link</p>
+<a style="display: block;" href="https://google.com/&lt&gt&amp&quot&#39">https://google.com/&lt&gt&amp&quot&#39</a>
+<a style="display: block;" href="http://example.org/testimg.png">http://example.org/testimg.png</a>
+<a style="display: block;" href="https://example.org/testimg.gif">A cool test image</a>
+<a style="display: block;" href="https://example.org:443/test.jpeg">https://example.org:443/test.jpeg</a>
+<p>=&gt gemini://example.org/testimg.png</p>
+<a style="display: block;" href="https://example.org/video.mp4">test video</a>
+<a style="display: block;" href="https://example.org/audio.mp3">test audio</a>
+<a style="display: block;" href="http://example.org/testimg.webp">http://example.org/testimg.webp</a>
+<a style="display: block;" href="mailto:someone@shtanton.xyz">Send an email!</a>
+<pre alt="Alt text">
+some stuff
+goes here
+dunnit
+
++----+
+|    |
++----+
+</pre>
+<pre>
+     spaghet
+&ltspan&gthello&lt/span&gt
+</pre>
+<h1>A heading</h1>
+<p>Some text</p>
+<h2>Another heading</h2>
+<h3>YEET!</h3>
+<ul>
+<li>Here is the first thing</li>
+<li>Here is the second</li>
+<li>Here is the third</li>
+</ul>
+<blockquote>This is a quote line, I quite like these as an idea and I use them sometimes</blockquote>
+<p>Back to some more text</p>

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -8,6 +8,14 @@ else
     exit 1
 fi
 
+if ./zig-out/bin/gmi2html --ignore-empty-lines < tests/source.gmi | diff -q tests/ignore_empty_lines_target.html - >/dev/null
+then
+    :
+else
+    echo "FAIL: translation ignoring empty lines did not match tests/ignore_empty_lines_target.html"
+    exit 1
+fi
+
 if ./zig-out/bin/gmi2html --inline-images < tests/source.gmi | diff -q tests/image_target.html - >/dev/null
 then
     :


### PR DESCRIPTION
I have added `--ignore-empty-lines` option to disable gmi2html to convert empty lines into `<p><br/></p>` elements.

```diff
$ diff target.html ignore_empty_lines_target.html
3d2
< <p><br/></p>
5d3
< <p><br/></p>
22d19
< <p><br/></p>
36d32
< <p><br/></p>
40,41d35
< <p><br/></p>
< <p><br/></p>
43d36
< <p><br/></p>
49d41
< <p><br/></p>
51d42
< <p><br/></p>
```

I tested on Ubuntu 22.04.